### PR TITLE
fix: qualify created_at column in user PRs query to prevent shadowing

### DIFF
--- a/github_metrics/app.py
+++ b/github_metrics/app.py
@@ -1793,7 +1793,7 @@ async def get_user_pull_requests(
           AND """
         + where_clause
         + """
-        ORDER BY repository, (payload->'pull_request'->>'number')::int DESC, created_at DESC
+        ORDER BY repository, (payload->'pull_request'->>'number')::int DESC, webhooks.created_at DESC
         LIMIT $"""
         + str(limit_param_idx)
         + " OFFSET $"


### PR DESCRIPTION
The SELECT clause aliases payload->'pull_request'->>'created_at' as 'created_at', which shadows the webhooks.created_at column in the ORDER BY clause. This caused DISTINCT ON to sort by PR creation time instead of webhook receipt time, resulting in stale PR state being returned (e.g., showing 'open' for merged PRs).

Fix: Use webhooks.created_at explicitly in ORDER BY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. Internal code improvements were made to enhance maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->