### PR TITLE
feat: add GitHub repo link to dashboard header

### DIFF
--- a/github_metrics/web/static/css/metrics_dashboard.css
+++ b/github_metrics/web/static/css/metrics_dashboard.css
@@ -590,6 +590,30 @@ h3 {
   align-items: center;
 }
 
+.github-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  color: var(--text-color);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  transition: all 0.3s ease;
+  text-decoration: none;
+}
+
+.github-link:hover {
+  color: var(--primary-color);
+  background: var(--input-bg);
+  border-color: var(--primary-color);
+  text-decoration: none;
+}
+
+.github-link svg {
+  display: block;
+}
+
 .chart-wrapper {
   position: relative;
   height: 250px; /* Standardized height */

--- a/github_metrics/web/templates/metrics_dashboard.html
+++ b/github_metrics/web/templates/metrics_dashboard.html
@@ -15,14 +15,35 @@
           <h1>GitHub Metrics Dashboard</h1>
           <p>Real-time monitoring of webhook processing metrics</p>
         </div>
-        <button
-          id="theme-toggle"
-          class="theme-toggle"
-          title="Toggle between light and dark theme"
-          aria-label="Toggle light or dark theme"
-        >
-          🌙
-        </button>
+        <div class="header-actions">
+          <a
+            href="https://github.com/myk-org/github-metrics"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="github-link"
+            aria-label="View source code on GitHub"
+            title="View source code on GitHub"
+          >
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+            </svg>
+          </a>
+          <button
+            id="theme-toggle"
+            class="theme-toggle"
+            title="Toggle between light and dark theme"
+            aria-label="Toggle light or dark theme"
+          >
+            🌙
+          </button>
+        </div>
       </div>
 
       <div class="status" id="connection-status">


### PR DESCRIPTION
Adds a GitHub icon link in the dashboard header that opens the repository (myk-org/github-metrics) in a new tab.

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub source-link button in the dashboard header for direct repository access
  * Introduced header-actions section to organize navigation controls while preserving existing theme-toggle functionality

* **Style**
  * Applied styling and interactive hover effects with enhanced visual feedback for the new GitHub link element

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->