### PR TITLE
fix: handle null/undefined values in DataTable sorting

### DIFF
--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -39,6 +39,15 @@ const getAlignClass = (align: ColumnDef<unknown>["align"]): string => {
   return "";
 };
 
+const stringifyValue = (val: unknown): string => {
+  if (typeof val === "string") return val;
+  if (typeof val === "number") return String(val);
+  if (typeof val === "boolean") return String(val);
+  if (typeof val === "object") return JSON.stringify(val);
+  // Symbol, function, or other edge cases
+  return "";
+};
+
 export function DataTable<T extends Record<string, unknown>>({
   columns,
   data,
@@ -99,15 +108,6 @@ export function DataTable<T extends Record<string, unknown>>({
       }
 
       // String comparison fallback - handle objects and primitives
-      const stringifyValue = (val: unknown): string => {
-        if (typeof val === "string") return val;
-        if (typeof val === "number") return String(val);
-        if (typeof val === "boolean") return String(val);
-        if (typeof val === "object") return JSON.stringify(val);
-        // Symbol, function, or other edge cases
-        return "";
-      };
-
       const aStr = stringifyValue(aVal);
       const bStr = stringifyValue(bVal);
       const comparison = aStr.localeCompare(bStr);


### PR DESCRIPTION
## Summary

Fixes issue #50 where "Response Time by Reviewer" sorting didn't work properly.

## Problem

- null/undefined values in sorting fell through to string comparison
- This produced incorrect sort order when comparing null values with numbers

## Solution

- Added explicit null/undefined handling in the `compareValues` function
- null/undefined values are now consistently sorted to the end
- Updated the `getValue` type annotation to include `null | undefined`

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Data tables now display null or undefined values as empty strings without errors.
  * Sorting consistently places null/undefined values at the end of results.
  * Non-numeric comparisons use improved value conversion for accurate sorting across types.
  * Numeric column sorting behavior preserved to maintain expected order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->