### PR TITLE
feat: add minimum review threshold for team dynamics

### DIFF
--- a/frontend/src/components/dashboard/filter-panel.tsx
+++ b/frontend/src/components/dashboard/filter-panel.tsx
@@ -121,7 +121,7 @@ export function FilterPanel({
   return (
     <CollapsibleSection title="Filters & Controls" defaultOpen={true}>
       <div className="flex flex-nowrap items-end gap-2 overflow-x-auto pb-4">
-        <div className="flex-1 space-y-1" style={{ minWidth: "140px" }}>
+        <div className="flex-1 space-y-1 min-w-[140px]">
           <Label htmlFor="quick-range" className="text-xs">
             Quick Range
           </Label>
@@ -138,7 +138,7 @@ export function FilterPanel({
           </Select>
         </div>
 
-        <div className="flex-1 space-y-1" style={{ minWidth: "210px" }}>
+        <div className="flex-1 space-y-1 min-w-[210px]">
           <Label htmlFor="start-time" className="text-xs">
             Start Time
           </Label>
@@ -154,7 +154,7 @@ export function FilterPanel({
           />
         </div>
 
-        <div className="flex-1 space-y-1" style={{ minWidth: "210px" }}>
+        <div className="flex-1 space-y-1 min-w-[210px]">
           <Label htmlFor="end-time" className="text-xs">
             End Time
           </Label>
@@ -170,7 +170,7 @@ export function FilterPanel({
           />
         </div>
 
-        <div className="flex-1 space-y-1" style={{ minWidth: "200px" }}>
+        <div className="flex-1 space-y-1 min-w-[200px]">
           <Label htmlFor="repositories" className="text-xs">
             Repositories
           </Label>
@@ -185,7 +185,7 @@ export function FilterPanel({
           />
         </div>
 
-        <div className="flex-1 space-y-1" style={{ minWidth: "180px" }}>
+        <div className="flex-1 space-y-1 min-w-[180px]">
           <Label htmlFor="users" className="text-xs">
             Users
           </Label>
@@ -200,7 +200,7 @@ export function FilterPanel({
           />
         </div>
 
-        <div className="flex-1 space-y-1" style={{ minWidth: "200px" }}>
+        <div className="flex-1 space-y-1 min-w-[200px]">
           <Label htmlFor="exclude-users" className="text-xs">
             Exclude Users
           </Label>
@@ -215,7 +215,7 @@ export function FilterPanel({
           />
         </div>
 
-        <div className="flex-shrink-0 space-y-1" style={{ minWidth: "150px" }}>
+        <div className="flex-shrink-0 space-y-1 min-w-[150px]">
           <Label className="text-xs invisible">Toggle</Label>
           <div className="flex items-center h-9 space-x-2">
             <Checkbox


### PR DESCRIPTION
## Summary

Fixes #52

This PR adds a configurable minimum review threshold for calculating fastest/slowest reviewers, ensuring statistically meaningful results and improving the reliability of team dynamics metrics.

## Changes

1. **Minimum Review Threshold**
   - Added `min_reviews` parameter (default: 5, configurable) to filter fastest/slowest reviewer calculations
   - Shows warning when sample size is below threshold with actual review count
   - When no reviewers meet threshold, uses those with maximum reviews (closest to threshold)

2. **Configuration Improvements**
   - Made SIG teams config optional in dev environment
   - Removed `sig-teams.yaml` from tracking (user-specific configuration)

3. **UI Fixes**
   - Fixed date picker width to prevent calendar icon cutoff
   - Increased Exclude Users dropdown width to prevent text wrapping

## Test Plan

- [x] Verified minimum review threshold logic works correctly
- [x] Tested fallback behavior when no reviewers meet threshold
- [x] Confirmed warning displays with actual review counts
- [x] Validated optional SIG teams configuration
- [x] Checked UI fixes for date picker and dropdown width
- [x] All tests pass (`tox`, `tox -e ui`, `bun run lint`, `prek run --all-files`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined dashboard filter panel spacing and width allocations for improved visual consistency and readability.
  * Replaced inline sizing with uniform utility-based classes, preserving layout and behavior while making Start Time, End Time, and Exclude Users controls slightly more consistent and spacious.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->